### PR TITLE
reset padding-left for all browsers

### DIFF
--- a/cn/2017/index.css
+++ b/cn/2017/index.css
@@ -13,7 +13,7 @@ body {
 
 ul {
   list-style: none;
-  -webkit-padding-start: 0;
+  padding-left: 0;
 }
 
 a {


### PR DESCRIPTION
原来的样式里只是在 Chrome 浏览器下修改了 padding，其他浏览器没变。所以在 Firefox 上面，会出现没有足够的空间显示完整的演讲标题的现象，就像这样：
![screenshot-2017-10-7 openresty con 2017](https://user-images.githubusercontent.com/4161644/31309707-42cbd466-abbd-11e7-810d-e26a2f4cecbc.png)